### PR TITLE
Fix/cqdg 670 device token changes

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -2,9 +2,8 @@ ferload-client {
   padding=50
   abbreviate=30
   config-name=".ferload-client.properties"
-  manifest-file-pointer="File IDEEEE",
-  manifest-filename="File NameEEE"
-  manifest-size="File SizeEEEE"
+  manifest-file-pointer="url",
+  manifest-size="size"
   manifest-separator="\t"
   download-files-pool=10
   download-agreement="yes"

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -2,8 +2,9 @@ ferload-client {
   padding=50
   abbreviate=30
   config-name=".ferload-client.properties"
-  manifest-header="url"
-  manifest-size="size"
+  manifest-file-pointer="File IDEEEE",
+  manifest-filename="File NameEEE"
+  manifest-size="File SizeEEEE"
   manifest-separator="\t"
   download-files-pool=10
   download-agreement="yes"

--- a/src/main/scala/ca/ferlab/ferload/client/clients/BaseHttpClient.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/clients/BaseHttpClient.scala
@@ -1,5 +1,6 @@
 package ca.ferlab.ferload.client.clients
 
+import ca.ferlab.ferload.client.LineContent
 import org.apache.http.HttpResponse
 import org.apache.http.client.methods.HttpRequestBase
 import org.apache.http.impl.client.{CloseableHttpClient, HttpClientBuilder}
@@ -29,7 +30,9 @@ abstract class BaseHttpClient {
     s"$message, code: $status, message:\n${body.getOrElse("")}"
   }
 
-  protected def toMap(body: Option[String]): Map[String, String] = {
-    body.map(new JSONObject(_).toMap.asScala.map({ case (key, value) => (key, value.toString) }).toMap).getOrElse(Map())
+  protected def toMap(body: Option[String], lineContents: Seq[LineContent]): Map[LineContent, String] = {
+    body.map(new JSONObject(_).toMap.asScala.map({ case (key, value) =>
+      lineContents.find(_.filePointer == key).get -> value.toString
+    }).toMap).getOrElse(Map())
   }
 }

--- a/src/main/scala/ca/ferlab/ferload/client/clients/inf/IFerload.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/clients/inf/IFerload.scala
@@ -1,9 +1,10 @@
 package ca.ferlab.ferload.client.clients.inf
 
+import ca.ferlab.ferload.client.{LineContent, ManifestContent}
 import org.json.JSONObject
 
 trait IFerload {
   def getConfig: JSONObject
 
-  def getDownloadLinks(token: String, manifestContent: String): Map[String, String]
+  def getDownloadLinks(token: String, manifestContent: ManifestContent): Map[LineContent, String]
 }

--- a/src/main/scala/ca/ferlab/ferload/client/clients/inf/IS3.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/clients/inf/IS3.scala
@@ -1,5 +1,7 @@
 package ca.ferlab.ferload.client.clients.inf
 
+import ca.ferlab.ferload.client.LineContent
+
 import java.io.File
 
 trait IS3 {
@@ -7,5 +9,5 @@ trait IS3 {
 
   def getTotalExpectedDownloadSize(links: Map[String, String], timeout: Long): Long
 
-  def download(outputDir: File, links: Map[String, String]): Set[File]
+  def download(outputDir: File, links: Map[LineContent, String]): Set[File]
 }

--- a/src/main/scala/ca/ferlab/ferload/client/commands/Configure.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/commands/Configure.scala
@@ -76,9 +76,18 @@ class Configure(userConfig: UserConfig, appConfig: Config, commandLine: ICommand
 
     } else if (KeycloakClient.AUTH_DEVICE == method) {
       val ferloadConfig = config.getJSONObject("keycloak")
+//      val clientConfig = if config.has("clientConfig") {Some(config.getJSONObject("clientConfig"))} else None //.getJSONObject("clientConfig")
+      val clientConfig = if (config.has("clientConfig")) {
+        Some(config.getJSONObject("clientConfig"))
+      } else {
+        None
+      }
       userConfig.set(KeycloakUrl, ferloadConfig.getString("url"))
       userConfig.set(KeycloakRealm, ferloadConfig.getString("realm"))
       userConfig.set(KeycloakAudience, ferloadConfig.getString("audience"))
+//      userConfig.set(ClientManifestFilePointer, clientConfig.getString("manifest-file-pointer"))
+//      userConfig.set(ClientManifestFileName, clientConfig.getString("manifest-filename"))
+//      userConfig.set(ClientManifestFileSize, clientConfig.getString("manifest-size"))
     } else {
       throw new IllegalStateException("Unknown authentication method: " + method)
     }

--- a/src/main/scala/ca/ferlab/ferload/client/commands/Configure.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/commands/Configure.scala
@@ -76,7 +76,6 @@ class Configure(userConfig: UserConfig, appConfig: Config, commandLine: ICommand
 
     } else if (KeycloakClient.AUTH_DEVICE == method) {
       val ferloadConfig = config.getJSONObject("keycloak")
-//      val clientConfig = if config.has("clientConfig") {Some(config.getJSONObject("clientConfig"))} else None //.getJSONObject("clientConfig")
       val clientConfig = if (config.has("clientConfig")) {
         Some(config.getJSONObject("clientConfig"))
       } else {
@@ -85,9 +84,13 @@ class Configure(userConfig: UserConfig, appConfig: Config, commandLine: ICommand
       userConfig.set(KeycloakUrl, ferloadConfig.getString("url"))
       userConfig.set(KeycloakRealm, ferloadConfig.getString("realm"))
       userConfig.set(KeycloakAudience, ferloadConfig.getString("audience"))
-//      userConfig.set(ClientManifestFilePointer, clientConfig.getString("manifest-file-pointer"))
-//      userConfig.set(ClientManifestFileName, clientConfig.getString("manifest-filename"))
-//      userConfig.set(ClientManifestFileSize, clientConfig.getString("manifest-size"))
+
+      clientConfig.foreach(config => {
+        userConfig.set(ClientManifestFilePointer, config.getString("manifest-file-pointer"))
+        userConfig.set(ClientManifestFileName, config.getString("manifest-filename"))
+        userConfig.set(ClientManifestFileSize, config.getString("manifest-size"))
+      })
+
     } else {
       throw new IllegalStateException("Unknown authentication method: " + method)
     }

--- a/src/main/scala/ca/ferlab/ferload/client/commands/Download.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/commands/Download.scala
@@ -171,7 +171,7 @@ class Download(userConfig: UserConfig,
 
   private def extractManifestContent: ManifestContent = {
     val manifestFilePointer = scala.Option(userConfig.get(ClientManifestFilePointer)).getOrElse(appConfig.getString("manifest-file-pointer"))
-    val manifestFileName = scala.Option(userConfig.get(ClientManifestFileName)).getOrElse(appConfig.getString("manifest-filename"))
+    val manifestFileName = scala.Option(userConfig.get(ClientManifestFileName))
     val manifestSize = scala.Option(userConfig.get(ClientManifestFileSize)).getOrElse(appConfig.getString("manifest-size"))
     val manifestSeparator = appConfig.getString("manifest-separator").charAt(0)
 
@@ -187,7 +187,7 @@ class Download(userConfig: UserConfig,
         .withFirstRecordAsHeader()
         .parse(reader)
       val fileIdColumnIndex = parser.getHeaderMap.getOrDefault(manifestFilePointer, -1)
-      val fileDisplayNameColumnIndex = parser.getHeaderMap.getOrDefault(manifestFileName, -1)
+      val fileDisplayNameColumnIndex = manifestFileName.map(displayCol => parser.getHeaderMap.getOrDefault(displayCol, -1)).map(_.toInt)
       val sizeColumnIndex = parser.getHeaderMap.getOrDefault(manifestSize, -1)
 
       if (fileIdColumnIndex == -1) {
@@ -195,7 +195,7 @@ class Download(userConfig: UserConfig,
       }
 
       val lines = parser.getRecords.stream().map(record => {
-          parseCVSRecord(record)(fileIdColumnIndex, fileDisplayNameColumnIndex, sizeColumnIndex)
+          parseCVSRecord(record)(fileIdColumnIndex, fileDisplayNameColumnIndex.getOrElse(-1), sizeColumnIndex)
         })
         .collect(toList[scala.Option[LineContent]])
         .asScala.toSeq.flatten

--- a/src/main/scala/ca/ferlab/ferload/client/commands/Download.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/commands/Download.scala
@@ -4,8 +4,9 @@ import ca.ferlab.ferload.client.clients.KeycloakClient
 import ca.ferlab.ferload.client.clients.inf.{ICommandLine, IFerload, IKeycloak, IS3}
 import ca.ferlab.ferload.client.commands.factory.{BaseCommand, CommandBlock}
 import ca.ferlab.ferload.client.configurations._
+import ca.ferlab.ferload.client.{LineContent, ManifestContent, OpsNum}
 import com.typesafe.config.Config
-import org.apache.commons.csv.CSVFormat
+import org.apache.commons.csv.{CSVFormat, CSVRecord}
 import org.apache.commons.io.FileUtils
 import org.apache.commons.lang3.StringUtils
 import picocli.CommandLine
@@ -13,7 +14,8 @@ import picocli.CommandLine.{Command, IExitCodeGenerator, Option}
 
 import java.io.{File, FileReader}
 import java.util.Optional
-import scala.collection.mutable
+import java.util.stream.Collectors.{summingInt, toList}
+import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try, Using}
 
 @Command(name = "download", mixinStandardHelpOptions = true, description = Array("Download files based on provided manifest."))
@@ -34,6 +36,7 @@ class Download(userConfig: UserConfig,
   var password: Optional[String] = Optional.empty
   
   private val NO_SIZE = 0L;
+
 
   override def run(): Unit = {
 
@@ -92,8 +95,8 @@ class Download(userConfig: UserConfig,
         }
       }
 
-      val links: Map[String, String] = CommandBlock("Retrieve Ferload download link(s)", successEmoji, padding) {
-        Try(ferload.getDownloadLinks(token, manifestContent.urls)) match {
+      val links: Map[LineContent, String] = CommandBlock("Retrieve Ferload download link(s)", successEmoji, padding) {
+        Try(ferload.getDownloadLinks(token, manifestContent)) match {
           case Success(links) => links
           case Failure(e) => {
             // always refresh token if failed
@@ -106,15 +109,14 @@ class Download(userConfig: UserConfig,
 
       val totalExpectedDownloadSize = CommandBlock("Compute total average expected download size", successEmoji, padding) {
         manifestContent.totalSize.getOrElse(
-          Try(s3.getTotalExpectedDownloadSize(links, appConfig.getLong("size-estimation-timeout"))) match {
+          Try(s3.getTotalExpectedDownloadSize(links.map{ case(k, v) => k.filePointer -> v }, appConfig.getLong("size-estimation-timeout"))) match {
             case Success(size) => size
-            case Failure(e) => {
+            case Failure(e) =>
               println()
               println()
               println(s"Failed to compute total average expected download size, reason: ${e.getMessage}")
               print(s"You can still proceed with the download, verify you have remaining disk-space available.")
               NO_SIZE
-            }
           })
       }
       
@@ -143,9 +145,34 @@ class Download(userConfig: UserConfig,
     }
   }
 
+
+  /**
+   * parse the input string into numeric size
+  @param input Input size string. Will accept size of the form: [123, 123 B, 123 KB, 123 MB, 123 GB, 123 TB]
+               if not units provided, it assumed to be bytes
+   */
+  private def extractSize (input: String): Long = {
+    if(input.isNumeric) {
+      input.toLong
+    } else {
+      val regex = "^([0-9.]+)\\s([A-Z]{1,2})$".r
+      val matched = regex.findAllIn(input)
+      val size = matched.group(1)
+      matched.group(2) match {
+        case "B" => size.toLong
+        case "KB" => size.toDouble.toLong * 1024L
+        case "MB" => (size.toDouble * math.pow(1024, 2)).toLong
+        case "GB" => (size.toDouble * math.pow(1024, 3)).toLong
+        case "TB" => (size.toDouble * math.pow(1024, 4)).toLong
+        case _ => throw new IllegalStateException(s"Size format not suitable: $input")
+      }
+    }
+  }
+
   private def extractManifestContent: ManifestContent = {
-    val manifestHeader = appConfig.getString("manifest-header")
-    val manifestSize = appConfig.getString("manifest-size")
+    val manifestFilePointer = scala.Option(userConfig.get(ClientManifestFilePointer)).getOrElse(appConfig.getString("manifest-file-pointer"))
+    val manifestFileName = scala.Option(userConfig.get(ClientManifestFileName)).getOrElse(appConfig.getString("manifest-filename"))
+    val manifestSize = scala.Option(userConfig.get(ClientManifestFileSize)).getOrElse(appConfig.getString("manifest-size"))
     val manifestSeparator = appConfig.getString("manifest-separator").charAt(0)
 
     if (!manifest.exists()) {
@@ -159,42 +186,54 @@ class Download(userConfig: UserConfig,
         .withTrim()
         .withFirstRecordAsHeader()
         .parse(reader)
-      val urls = new mutable.StringBuilder
-      var totalSize = NO_SIZE
-      val fileIdColumnIndex = parser.getHeaderMap.getOrDefault(manifestHeader, -1)
+      val fileIdColumnIndex = parser.getHeaderMap.getOrDefault(manifestFilePointer, -1)
+      val fileDisplayNameColumnIndex = parser.getHeaderMap.getOrDefault(manifestFileName, -1)
       val sizeColumnIndex = parser.getHeaderMap.getOrDefault(manifestSize, -1)
 
       if (fileIdColumnIndex == -1) {
-        throw new IllegalStateException("Missing column: " + manifestHeader)
+        throw new IllegalStateException("Missing column: " + manifestFilePointer)
       }
 
-      parser.getRecords.stream().forEach(record => {
-        val url = record.get(fileIdColumnIndex)
-        if (StringUtils.isNotBlank(url)) {
-          urls.append(s"$url\n")
-        }
-        if (record.isSet(sizeColumnIndex)) {  // size column exist (optional)
-          val size = record.get(sizeColumnIndex)
-          if (StringUtils.isNotBlank(size)) {
-            totalSize += size.toLong
-          }
-        }
-      })
+      val lines = parser.getRecords.stream().map(record => {
+          parseCVSRecord(record)(fileIdColumnIndex, fileDisplayNameColumnIndex, sizeColumnIndex)
+        })
+        .collect(toList[scala.Option[LineContent]])
+        .asScala.toSeq.flatten
 
-      if (urls.isEmpty) {
+      if (lines.isEmpty) {
         throw new IllegalStateException("Empty content")
       }
+      val hasEmptyFileSizes = lines.exists(l => l.size.isEmpty)
 
+      val totalSize = if (hasEmptyFileSizes) {
+        None
+      } else {
+        val size = lines.foldLeft(0L) { (acc, l) =>
+          l.size.map(s => acc + s).getOrElse(0L)
+        }
+        Some(size)
+      }
 
-      ManifestContent(urls.toString(), if(totalSize == NO_SIZE) None else Some(totalSize))
+      ManifestContent(lines, totalSize)
 
     } match {
       case Success(value) => value
       case Failure(e) => throw new IllegalStateException(s"Invalid manifest file: " + e.getMessage, e)
     }
   }
+
+  private def parseCVSRecord (record: CSVRecord)
+                             (filePointerColIndex: Int, displayColIndex: Int, sizeColIndex: Int): scala.Option[LineContent] = {
+    val pointer =  record.get(filePointerColIndex)
+    val display =  if(displayColIndex >= 0) Some(record.get(displayColIndex)) else None
+    val size = if(sizeColIndex >= 0) Some(record.get(sizeColIndex)) else None
+
+    if (StringUtils.isNotBlank(pointer)) {
+      Some(LineContent(pointer, display,  size.map(extractSize)))
+    } else None
+  }
   
-  case class ManifestContent(urls: String, totalSize: scala.Option[Long])
+
 
   override def getExitCode: Int = 1
 

--- a/src/main/scala/ca/ferlab/ferload/client/commands/package.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/commands/package.scala
@@ -1,0 +1,5 @@
+package ca.ferlab.ferload.client
+
+package object commands {
+
+}

--- a/src/main/scala/ca/ferlab/ferload/client/configurations/UserConfigName.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/configurations/UserConfigName.scala
@@ -25,3 +25,9 @@ case object TokenClientId extends UserConfigName("token-client-id")
 case object TokenLink extends UserConfigName("token-link")
 
 case object TokenHelper extends UserConfigName("token-helper")
+
+case object ClientManifestFilePointer extends UserConfigName("clientConfig-manifest-file-pointer")
+
+case object ClientManifestFileName extends UserConfigName("clientConfig-manifest-filename")
+
+case object ClientManifestFileSize extends UserConfigName("clientConfig-manifest-size")

--- a/src/main/scala/ca/ferlab/ferload/client/configurations/UserConfigName.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/configurations/UserConfigName.scala
@@ -26,8 +26,8 @@ case object TokenLink extends UserConfigName("token-link")
 
 case object TokenHelper extends UserConfigName("token-helper")
 
-case object ClientManifestFilePointer extends UserConfigName("clientConfig-manifest-file-pointer")
+case object ClientManifestFilePointer extends UserConfigName("client-config-manifest-file-pointer")
 
-case object ClientManifestFileName extends UserConfigName("clientConfig-manifest-filename")
+case object ClientManifestFileName extends UserConfigName("client-config-manifest-filename")
 
-case object ClientManifestFileSize extends UserConfigName("clientConfig-manifest-size")
+case object ClientManifestFileSize extends UserConfigName("client-config-manifest-size")

--- a/src/main/scala/ca/ferlab/ferload/client/package.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/package.scala
@@ -1,0 +1,13 @@
+package ca.ferlab.ferload
+
+package object client {
+
+  implicit class OpsNum(val str: String) {
+    def isNumeric: Boolean = scala.util.Try(str.toDouble).isSuccess
+  }
+
+  case class LineContent(filePointer: String, fileName: Option[String], size: Option[Long])
+
+  case class ManifestContent(lines: Seq[LineContent], totalSize: Option[Long])
+
+}

--- a/src/main/scala/ca/ferlab/ferload/client/package.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/package.scala
@@ -6,7 +6,7 @@ package object client {
     def isNumeric: Boolean = scala.util.Try(str.toDouble).isSuccess
   }
 
-  case class LineContent(filePointer: String, fileName: Option[String], size: Option[Long])
+  case class LineContent(filePointer: String, fileName: Option[String] = None, size: Option[Long] = None)
 
   case class ManifestContent(lines: Seq[LineContent], totalSize: Option[Long])
 

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -3,5 +3,5 @@ ferload-client {
   abbreviate=10
   config-name=".ferload-client.properties"
   contact="Phone: +1 (999) 999-999 or email: ferlab@ferlab.bio"
-  manifest-header="file_id"
+  manifest-file-pointer="file_id"
 }

--- a/src/test/resources/manifest-valid.tsv
+++ b/src/test/resources/manifest-valid.tsv
@@ -1,4 +1,4 @@
 file_id	size
 file1	1
-file2	1
-file3	1
+file2	1 B
+file3	1 MB

--- a/src/test/scala/ca/ferlab/ferload/client/commands/ConfigureTest.scala
+++ b/src/test/scala/ca/ferlab/ferload/client/commands/ConfigureTest.scala
@@ -1,5 +1,6 @@
 package ca.ferlab.ferload.client.commands
 
+import ca.ferlab.ferload.client.{LineContent, ManifestContent}
 import ca.ferlab.ferload.client.clients.inf.{ICommandLine, IFerload}
 import ca.ferlab.ferload.client.configurations._
 import com.typesafe.config.{Config, ConfigFactory}
@@ -58,25 +59,25 @@ class ConfigureTest extends AnyFunSuite with BeforeAndAfter {
   val mockFerloadInf: IFerload = new IFerload {
     override def getConfig: JSONObject = mockFerloadConfigPassword
 
-    override def getDownloadLinks(token: String, manifestContent: String): Map[String, String] = ???
+    override def getDownloadLinks(token: String, manifestContent: ManifestContent): Map[LineContent, String] = ???
   }
 
   val mockFerloadTokenInf: IFerload = new IFerload {
     override def getConfig: JSONObject = mockFerloadConfigToken
 
-    override def getDownloadLinks(token: String, manifestContent: String): Map[String, String] = ???
+    override def getDownloadLinks(token: String, manifestContent: ManifestContent): Map[LineContent, String] = ???
   }
 
   val mockFerloadDeviceInf: IFerload = new IFerload {
     override def getConfig: JSONObject = mockFerloadConfigDevice
 
-    override def getDownloadLinks(token: String, manifestContent: String): Map[String, String] = ???
+    override def getDownloadLinks(token: String, manifestContent: ManifestContent): Map[LineContent, String] = ???
   }
 
   val mockFerloadUnkownMethodInf: IFerload = new IFerload {
     override def getConfig: JSONObject = new JSONObject().put("method", "foo")
 
-    override def getDownloadLinks(token: String, manifestContent: String): Map[String, String] = ???
+    override def getDownloadLinks(token: String, manifestContent: ManifestContent): Map[LineContent, String] = ???
   }
 
   before {

--- a/src/test/scala/ca/ferlab/ferload/client/commands/DownloadTest.scala
+++ b/src/test/scala/ca/ferlab/ferload/client/commands/DownloadTest.scala
@@ -1,5 +1,6 @@
 package ca.ferlab.ferload.client.commands
 
+import ca.ferlab.ferload.client.{LineContent, ManifestContent}
 import ca.ferlab.ferload.client.clients.inf.{ICommandLine, IFerload, IKeycloak, IS3}
 import ca.ferlab.ferload.client.configurations._
 import com.typesafe.config.{Config, ConfigFactory}
@@ -73,9 +74,9 @@ class DownloadTest extends AnyFunSuite with BeforeAndAfter {
   }
 
   val mockFerload: IFerload = new IFerload {
-    override def getDownloadLinks(token: String, manifestContent: String): Map[String, String] = {
+    override def getDownloadLinks(token: String, manifestContent: ManifestContent): Map[LineContent, String] = {
       assert(token.equals("token"))
-      Map("f1" -> "link1", "f2" -> "link2", "f2" -> "link2")
+      Map(LineContent(filePointer = "f1") -> "link1", LineContent(filePointer = "f2") -> "link2", LineContent(filePointer = "f3") -> "link3")
     }
 
     override def getConfig: JSONObject = mockFerloadConfigPassword
@@ -123,7 +124,7 @@ class DownloadTest extends AnyFunSuite with BeforeAndAfter {
   test("call keycloak / ferload") {
 
     val mockS3: IS3 = new IS3 {
-      override def download(outputDir: File, links: Map[String, String]): Set[File] = {
+      override def download(outputDir: File, links: Map[LineContent, String]): Set[File] = {
         assert(links.size == 2)
         Set(new File("f1"), new File("f2"))
       }
@@ -140,7 +141,7 @@ class DownloadTest extends AnyFunSuite with BeforeAndAfter {
   test("did not agreed to download") {
 
     val mockS3: IS3 = new IS3 {
-      override def download(outputDir: File, links: Map[String, String]): Set[File] = {
+      override def download(outputDir: File, links: Map[LineContent, String]): Set[File] = {
         assert(links.size == 2)
         Set(new File("f1"), new File("f2"))
       }
@@ -157,7 +158,7 @@ class DownloadTest extends AnyFunSuite with BeforeAndAfter {
   test("not enough disk space") {
 
     val mockS3: IS3 = new IS3 {
-      override def download(outputDir: File, links: Map[String, String]): Set[File] = {
+      override def download(outputDir: File, links: Map[LineContent, String]): Set[File] = {
         assert(links.size == 2)
         Set(new File("f1"), new File("f2"))
       }
@@ -174,7 +175,7 @@ class DownloadTest extends AnyFunSuite with BeforeAndAfter {
   test("stored token is valid") {
 
     val mockS3: IS3 = new IS3 {
-      override def download(outputDir: File, links: Map[String, String]): Set[File] = {
+      override def download(outputDir: File, links: Map[LineContent, String]): Set[File] = {
         assert(links.size == 2)
         Set(new File("f1"), new File("f2"))
       }


### PR DESCRIPTION
Changes:

1. Rename config parameter `manifest-header` to `manifest-file-pointer`. I find the original name confusing for the purpose of this column. But it is only cosmetic change.. 

2. The manifest-size column values can have string values. For CQDG the file manifest contains values to the type `1.00 B`, `1.00 MB`,... We need to parse these. However, if the values are of numeric type, they are still supported.

3. The config supplied by the `application.conf ` file is still used. But it can be overwritten by the configuration supplied by the Ferload server, if it is supplied (as it will be in the case of CQDG).

4. Relating to no 3 point. In CQDG, we have an extra config column: `manifest-filename`. This column is optional. If supplied, it will be used to name all the files once they are saved by the user. If not supplied, the name of the files will be the values present in, the now named, `manifest-file-pointer` (as was the previous default behaviour). 

 Exemple of conf supplied by the ferload server (CQDG):
 
 
![Screenshot from 2024-05-10 08-58-01](https://github.com/Ferlab-Ste-Justine/ferload-client-cli/assets/29788342/06d6a799-d94c-49a3-9ee3-26e2d9ed0b71)

