### PR TITLE
feat/CQDG-752 and CQDG-753 display unauthorized documents / refresh token

### DIFF
--- a/src/main/scala/ca/ferlab/ferload/client/Main.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/Main.scala
@@ -11,7 +11,7 @@ import picocli.CommandLine.Command
 import java.io.File
 
 @Command(name = "ferload-client", mixinStandardHelpOptions = true,
-  version = Array("2.0.0"),
+  version = Array("2.1.0"),
   description = Array("Official Ferload Client command line interface for files download."),
   subcommands = Array(classOf[Configure], classOf[Download]))
 class Main extends Runnable {

--- a/src/main/scala/ca/ferlab/ferload/client/clients/BaseHttpClient.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/clients/BaseHttpClient.scala
@@ -8,7 +8,6 @@ import org.apache.http.util.EntityUtils
 import org.json.JSONObject
 
 import scala.jdk.CollectionConverters.MapHasAsScala // scala 2.13
-// import scala.collection.JavaConverters._ // scala 2.12
 
 abstract class BaseHttpClient {
 
@@ -27,7 +26,9 @@ abstract class BaseHttpClient {
   }
 
   protected def formatExceptionMessage(message: String, status: Int, body: Option[String]): String = {
-    s"$message, code: $status, message:\n${body.getOrElse("")}"
+    val msg = body.map(r => new JSONObject(r).get("msg"))
+
+    s"$message, code: $status, message:\n${msg.getOrElse("")}"
   }
 
   protected def toMap(body: Option[String], lineContents: Seq[LineContent]): Map[LineContent, String] = {

--- a/src/main/scala/ca/ferlab/ferload/client/clients/FerloadClient.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/clients/FerloadClient.scala
@@ -27,7 +27,7 @@ class FerloadClient(userConfig: UserConfig) extends BaseHttpClient with IFerload
     val (body, status) = executeHttpRequest(httpRequest)
     status match {
       case 200 => toMap(body, manifestContent.lines)
-      case 403 => throw new IllegalStateException(formatExceptionMessage("No enough access rights to download the following files", status, body))
+      case 403 => throw new UnauthorizedException(formatExceptionMessage("No enough access rights to download the following files", status, body))
       case _ => throw new IllegalStateException(formatExceptionMessage("Failed to retrieve download link(s)", status, body))
     }
   }

--- a/src/main/scala/ca/ferlab/ferload/client/clients/UnauthorizedException.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/clients/UnauthorizedException.scala
@@ -1,0 +1,7 @@
+package ca.ferlab.ferload.client.clients
+
+import scala.util.control.NoStackTrace
+
+class UnauthorizedException(message: String) extends RuntimeException with NoStackTrace {
+  override def getMessage: String = message
+}

--- a/src/main/scala/ca/ferlab/ferload/client/clients/inf/IKeycloak.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/clients/inf/IKeycloak.scala
@@ -7,7 +7,9 @@ trait IKeycloak {
 
   def getDevice: JSONObject
 
-  def getUserDeviceToken(deviceCode: String, expiresIn: Int): String
+  def getUserDeviceToken(deviceCode: String, expiresIn: Int): (String, String)
+
+  def getRefreshedTokens(refreshToken: String)(realm: String, client: String): (String, String)
 
   def isValidToken(token: String): Boolean
 }

--- a/src/main/scala/ca/ferlab/ferload/client/configurations/UserConfigName.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/configurations/UserConfigName.scala
@@ -8,6 +8,8 @@ case object Username extends UserConfigName("username")
 
 case object Token extends UserConfigName("token")
 
+case object RefreshToken extends UserConfigName("refresh_token")
+
 case object KeycloakUrl extends UserConfigName("keycloak-url")
 
 case object KeycloakRealm extends UserConfigName("keycloak-realm")

--- a/src/test/scala/ca/ferlab/ferload/client/commands/DownloadTest.scala
+++ b/src/test/scala/ca/ferlab/ferload/client/commands/DownloadTest.scala
@@ -67,7 +67,9 @@ class DownloadTest extends AnyFunSuite with BeforeAndAfter {
 
     override def getDevice: JSONObject = ???
 
-    override def getUserDeviceToken(deviceCode: String, expiresIn: Int): String = ???
+    override def getUserDeviceToken(deviceCode: String, expiresIn: Int): (String, String) = ???
+
+    override def getRefreshedTokens(refreshToken: String)(realm: String, client: String): (String, String) = ???
   }
 
   val mockKeycloakValidTokenInf: IKeycloak = new IKeycloak {
@@ -77,7 +79,9 @@ class DownloadTest extends AnyFunSuite with BeforeAndAfter {
 
     override def getDevice: JSONObject = ???
 
-    override def getUserDeviceToken(deviceCode: String, expiresIn: Int): String = ???
+    override def getUserDeviceToken(deviceCode: String, expiresIn: Int): (String, String) = ???
+
+    override def getRefreshedTokens(refreshToken: String)(realm: String, client: String): (String, String) = ???
   }
 
   val mockFerload: IFerload = new IFerload {


### PR DESCRIPTION
changes:

- extract message from ferload server response and display unauthorised files (CQDG-752)
- if refresh_token is still valid, use it to fetch a new access_token. Users not required to authenticate with each device method download requests. (CQDG-753)

ex: 

unauthorised files

![Screenshot from 2024-05-27 09-01-16](https://github.com/Ferlab-Ste-Justine/ferload-client-cli/assets/29788342/26bac29d-0b93-4ea0-b10e-f40a884cd990)

use refresh token:
![Screenshot from 2024-05-27 09-11-11](https://github.com/Ferlab-Ste-Justine/ferload-client-cli/assets/29788342/4b29fbe9-11a4-4329-b1d3-ee5b7cc5f905)

