### PR TITLE
Fix/cqdg 839 manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,33 @@ FIL0000002  [##################################################]     76 /     76
 Total downloaded files: 12 located here: ./data
 
 ```
+### Example (download with device token using a manifest id)
+```
+user@localhost:~$ ./ferload-client download -i 800a290f-edcc-4ece-8c83-449fc1694afd -o ./data
+
+Welcome to Ferload Client, this tools will download
+the files based on the provided manifest.
+
+Retrieve device token                              ✅
+
+Copy/Paste this URL in your browser and login please: http://localhost:32771/realms/CQDG/device?user_code=NNLJ-AOOQ
+ ✅ 
+ 
+Retrieving Manifest from ID                        ✅
+
+Checking manifest file                             ✅
+
+Compute total average expected download size       ✅
+
+The total average expected download size will be 76 MB do you want to continue (your available disk space is: 60 GB) ? [yes]: yes
+
+FIL0000001  [##################################################]     76 /     76 MB (100%) 📦
+FIL0000002  [##################################################]     76 /     76 MB (100%) 📦
+
+Total downloaded files: 12 located here: ./data
+
+```
+
 
 *Note: in case the tool can't compute the total average expected download size, the following message will be displayed:*
 ```

--- a/README.md
+++ b/README.md
@@ -116,14 +116,18 @@ Configuration has been successfully updated ✅
 By providing a manifest file and an output folder the tool will start downloading the files. This step is done concurrently with a secured hash validation for file integrity.
 ### Usage
 ```
-Usage: ferload-client download [-hV] [-m=<manifest>] [-o=<outputDir>]
+Usage: ferload-client download [-hV] [(-m=<manifest> | -i=<manifestId>)] [-o=<outputDir>]
                                [-p=<password>]
 Download files based on provided manifest.
   -h, --help      Show this help message and exit.
   -m, --manifest=<manifest>
                   manifest file location (default: manifest.tsv)
+  -i, --manifest-id=<manifestId>
+                  manifest id containing the files to download  
   -o, --output-dir=<outputDir>
                   downloads location (default: .)
+  -n, --manifest-only   
+                  download the manifest only in tsv format supplied manifest id.
   -V, --version   Print version information and exit.
 ```
 

--- a/README.md
+++ b/README.md
@@ -116,18 +116,16 @@ Configuration has been successfully updated ✅
 By providing a manifest file and an output folder the tool will start downloading the files. This step is done concurrently with a secured hash validation for file integrity.
 ### Usage
 ```
-Usage: ferload-client download [-hV] [(-m=<manifest> | -i=<manifestId>)] [-o=<outputDir>]
-                               [-p=<password>]
+Usage: ferload-client download [-hV] [-o=<outputDir>] [-p=<password>]
+                               (-m=<byManifest> | (-i=<id> [--manifest-only]))
 Download files based on provided manifest.
   -h, --help      Show this help message and exit.
-  -m, --manifest=<manifest>
-                  manifest file location (default: manifest.tsv)
-  -i, --manifest-id=<manifestId>
-                  manifest id containing the files to download  
+  -i, --manifest-id=<id>   manifest ID
+      --manifest-only      Download the manifest only from the manifest id
+  -m, --manifest=<byManifest>
+                           manifest file location
   -o, --output-dir=<outputDir>
                   downloads location (default: .)
-  -n, --manifest-only   
-                  download the manifest only in tsv format supplied manifest id.
   -V, --version   Print version information and exit.
 ```
 
@@ -140,11 +138,11 @@ user@localhost:~$ ./ferload-client download -m ./data/m1.tsv -o ./data
 Welcome to Ferload Client, this tools will download
 the files based on the provided manifest.
 
-Checking manifest file                             ✅
-
 password                                   [hidden]:
 
 Retrieve user credentials                          ✅
+
+Checking manifest file                             ✅
 
 Retrieve Ferload download link(s)                  ✅
 
@@ -176,12 +174,12 @@ user@localhost:~$ ./ferload-client download -m ./data/m1.tsv -o ./data
 Welcome to Ferload Client, this tools will download
 the files based on the provided manifest.
 
-Checking manifest file                             ✅
-
 Retrieve device token                              ✅
 
 Copy/Paste this URL in your browser and login please: http://localhost:32771/realms/CQDG/device?user_code=NNLJ-AOOQ
  ✅ 
+ 
+Checking manifest file                             ✅
 
 Retrieve Ferload download link(s)                  ✅
 

--- a/src/main/scala/ca/ferlab/ferload/client/Main.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/Main.scala
@@ -11,7 +11,7 @@ import picocli.CommandLine.Command
 import java.io.File
 
 @Command(name = "ferload-client", mixinStandardHelpOptions = true,
-  version = Array("2.1.1"),
+  version = Array("2.2.0"),
   description = Array("Official Ferload Client command line interface for files download."),
   subcommands = Array(classOf[Configure], classOf[Download]))
 class Main extends Runnable {

--- a/src/main/scala/ca/ferlab/ferload/client/clients/BaseHttpClient.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/clients/BaseHttpClient.scala
@@ -1,14 +1,15 @@
 package ca.ferlab.ferload.client.clients
 
 import ca.ferlab.ferload.client.LineContent
-import org.apache.http.HttpResponse
+import org.apache.http.{HttpEntity, HttpResponse}
 import org.apache.http.client.methods.HttpRequestBase
 import org.apache.http.impl.client.{CloseableHttpClient, HttpClientBuilder}
 import org.apache.http.util.EntityUtils
 import org.json.JSONObject
 
 import java.io.{File, FileOutputStream}
-import scala.jdk.CollectionConverters.MapHasAsScala // scala 2.13
+import scala.jdk.CollectionConverters.MapHasAsScala
+import scala.util.{Failure, Success, Try} // scala 2.13
 
 abstract class BaseHttpClient {
 
@@ -26,23 +27,31 @@ abstract class BaseHttpClient {
     (body, response.getStatusLine.getStatusCode)
   }
 
-  protected def executeHttpRequestAndDownload(request: HttpRequestBase, path: String, manifestId: String): Unit = {
+  protected def executeHttpRequestAndDownload(request: HttpRequestBase, path: String, manifestId: String): Either[Error, Unit] = {
     val response: HttpResponse = http.execute(request)
-    val entity = response.getEntity
+    val extraction = Option(response.getEntity).map(e =>
+      response.getStatusLine.getStatusCode match {
+        case status if status < 300 => extractEntityLinesToFile(e, s"$path/$manifestId.tsv")
+        case status => Left(Error(s"Failed to retrieve manifest for id: $manifestId, code: $status"))
+      }
+    ).getOrElse(Left(Error("Unknown Response status")))
 
-    response.getStatusLine.getStatusCode match {
-      case status if status < 300 =>
-        try {
-          val manifestFile = new File(s"$path/$manifestId.tsv")
-          val outputStream: FileOutputStream = new FileOutputStream(manifestFile)
-          try entity.writeTo(outputStream)
-          finally if (outputStream != null) outputStream.close()
-        }
-      case status =>
-        throw new IllegalStateException(s"Failed to retrieve manifest for id: $manifestId, code: $status")
-    }
     // always properly close
     EntityUtils.consumeQuietly(response.getEntity)
+
+    extraction
+  }
+
+  private def extractEntityLinesToFile(entity: HttpEntity, filePath: String): Either[Error, Unit] = {
+    Try {
+      val manifestFile = new File(filePath)
+      val outputStream: FileOutputStream = new FileOutputStream(manifestFile)
+      try entity.writeTo(outputStream)
+      finally if (outputStream != null) outputStream.close()
+    } match {
+      case Success(_) => Right()
+      case Failure(e) => Left(Error(e.getMessage))
+    }
   }
 
   protected def formatExceptionMessage(message: String, status: Int, body: Option[String]): String = {

--- a/src/main/scala/ca/ferlab/ferload/client/clients/Error.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/clients/Error.scala
@@ -1,0 +1,5 @@
+package ca.ferlab.ferload.client.clients
+
+case class Error(message: String) {
+
+}

--- a/src/main/scala/ca/ferlab/ferload/client/clients/ReportApiClient.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/clients/ReportApiClient.scala
@@ -5,8 +5,8 @@ import ca.ferlab.ferload.client.configurations._
 import org.apache.http.HttpHeaders
 import org.apache.http.client.methods.HttpGet
 import org.apache.http.entity.ContentType
-import java.util.stream.Stream
 
+import java.util.stream.Stream
 import java.net.URI
 import java.util.stream.Collectors
 import scala.jdk.CollectionConverters.CollectionHasAsScala
@@ -15,7 +15,7 @@ class ReportApiClient(userConfig: UserConfig) extends BaseHttpClient with IRepor
   lazy val url: String = userConfig.get(ReportApiManifestUrl)
 
 
-  override def getManifestContentById(manifestId: String, token: String): List[String] = {
+  override def getManifestContentById(manifestId: String, token: String): Either[Error, List[String]] = {
     val requestUri = new URI(s"$url/$manifestId")
     val httpRequest = new HttpGet(requestUri)
     httpRequest.addHeader(HttpHeaders.AUTHORIZATION, s"Bearer $token")
@@ -24,17 +24,24 @@ class ReportApiClient(userConfig: UserConfig) extends BaseHttpClient with IRepor
 
     status match {
       case s if s < 300  =>
-        body.get.lines.asInstanceOf[Stream[String]].collect(Collectors.toList[String]).asScala.toList
-      case _ => throw new IllegalStateException(formatExceptionMessage(s"Failed to retrieve manifest for id: $manifestId", status, body))
+        Right(body.get.lines.asInstanceOf[Stream[String]].collect(Collectors.toList[String]).asScala.toList)
+      case _ => Left(Error(formatExceptionMessage(s"Failed to retrieve manifest for id: $manifestId", status, body)))
     }
   }
 
-  override def downloadManifestById(manifestId: String, token: String, outputDir: String): Unit = {
+
+  /**
+   * Download the manifest by ID from report api service
+   * @param manifestId id of the manifest to download
+   * @param token jwt token of the user
+   * @param outputDir path were to save the file
+   * @return `Right` nothing if manifest was downloaded or `Left` with an Exception is error occurred
+   * */
+  override def downloadManifestById(manifestId: String, token: String, outputDir: String):Either[Error, Unit] = {
     val requestUri = new URI(s"$url/$manifestId")
     val httpRequest = new HttpGet(requestUri)
     httpRequest.addHeader(HttpHeaders.AUTHORIZATION, s"Bearer $token")
     httpRequest.addHeader(HttpHeaders.CONTENT_TYPE, ContentType.TEXT_PLAIN.getMimeType)
     executeHttpRequestAndDownload(httpRequest, outputDir, manifestId)
-
   }
 }

--- a/src/main/scala/ca/ferlab/ferload/client/clients/ReportApiClient.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/clients/ReportApiClient.scala
@@ -1,0 +1,30 @@
+package ca.ferlab.ferload.client.clients
+
+import ca.ferlab.ferload.client.clients.inf.IReportApi
+import ca.ferlab.ferload.client.configurations._
+import org.apache.http.HttpHeaders
+import org.apache.http.client.methods.HttpGet
+import org.apache.http.entity.ContentType
+
+import java.net.URI
+import java.util.stream.Collectors
+import scala.jdk.CollectionConverters.CollectionHasAsScala
+
+class ReportApiClient(userConfig: UserConfig) extends BaseHttpClient with IReportApi {
+  lazy val url: String = userConfig.get(ReportApiManifestUrl)
+
+
+  override def getManifestById(manifestId: String, token: String): List[String] = {
+    val requestUri = new URI(s"$url/$manifestId")
+    val httpRequest = new HttpGet(requestUri)
+    httpRequest.addHeader(HttpHeaders.AUTHORIZATION, s"Bearer $token")
+    httpRequest.addHeader(HttpHeaders.CONTENT_TYPE, ContentType.TEXT_PLAIN.getMimeType)
+    val (body, status) = executeHttpRequest(httpRequest)
+
+    status match {
+      case s if s < 300  => body.get.lines().collect(Collectors.toList[String]).asScala.toList
+      case _ => throw new IllegalStateException(formatExceptionMessage(s"Failed to retrieve manifest for id: $manifestId", status, body))
+    }
+  }
+
+}

--- a/src/main/scala/ca/ferlab/ferload/client/clients/ReportApiClient.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/clients/ReportApiClient.scala
@@ -14,7 +14,7 @@ class ReportApiClient(userConfig: UserConfig) extends BaseHttpClient with IRepor
   lazy val url: String = userConfig.get(ReportApiManifestUrl)
 
 
-  override def getManifestById(manifestId: String, token: String): List[String] = {
+  override def getManifestContentById(manifestId: String, token: String): List[String] = {
     val requestUri = new URI(s"$url/$manifestId")
     val httpRequest = new HttpGet(requestUri)
     httpRequest.addHeader(HttpHeaders.AUTHORIZATION, s"Bearer $token")
@@ -27,4 +27,12 @@ class ReportApiClient(userConfig: UserConfig) extends BaseHttpClient with IRepor
     }
   }
 
+  override def downloadManifestById(manifestId: String, token: String, outputDir: String): Unit = {
+    val requestUri = new URI(s"$url/$manifestId")
+    val httpRequest = new HttpGet(requestUri)
+    httpRequest.addHeader(HttpHeaders.AUTHORIZATION, s"Bearer $token")
+    httpRequest.addHeader(HttpHeaders.CONTENT_TYPE, ContentType.TEXT_PLAIN.getMimeType)
+    val status = executeHttpRequestAndDownload(httpRequest, outputDir, manifestId)
+
+  }
 }

--- a/src/main/scala/ca/ferlab/ferload/client/clients/ReportApiClient.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/clients/ReportApiClient.scala
@@ -5,6 +5,7 @@ import ca.ferlab.ferload.client.configurations._
 import org.apache.http.HttpHeaders
 import org.apache.http.client.methods.HttpGet
 import org.apache.http.entity.ContentType
+import java.util.stream.Stream
 
 import java.net.URI
 import java.util.stream.Collectors
@@ -22,7 +23,8 @@ class ReportApiClient(userConfig: UserConfig) extends BaseHttpClient with IRepor
     val (body, status) = executeHttpRequest(httpRequest)
 
     status match {
-      case s if s < 300  => body.get.lines().collect(Collectors.toList[String]).asScala.toList
+      case s if s < 300  =>
+        body.get.lines.asInstanceOf[Stream[String]].collect(Collectors.toList[String]).asScala.toList
       case _ => throw new IllegalStateException(formatExceptionMessage(s"Failed to retrieve manifest for id: $manifestId", status, body))
     }
   }
@@ -32,7 +34,7 @@ class ReportApiClient(userConfig: UserConfig) extends BaseHttpClient with IRepor
     val httpRequest = new HttpGet(requestUri)
     httpRequest.addHeader(HttpHeaders.AUTHORIZATION, s"Bearer $token")
     httpRequest.addHeader(HttpHeaders.CONTENT_TYPE, ContentType.TEXT_PLAIN.getMimeType)
-    val status = executeHttpRequestAndDownload(httpRequest, outputDir, manifestId)
+    executeHttpRequestAndDownload(httpRequest, outputDir, manifestId)
 
   }
 }

--- a/src/main/scala/ca/ferlab/ferload/client/clients/inf/IFerload.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/clients/inf/IFerload.scala
@@ -1,10 +1,11 @@
 package ca.ferlab.ferload.client.clients.inf
 
+import ca.ferlab.ferload.client.clients.Error
 import ca.ferlab.ferload.client.{LineContent, ManifestContent}
 import org.json.JSONObject
 
 trait IFerload {
   def getConfig: JSONObject
 
-  def getDownloadLinks(token: String, manifestContent: ManifestContent): Map[LineContent, String]
+  def getDownloadLinks(token: String, manifestContent: ManifestContent): Either[Error, Map[LineContent, String]]
 }

--- a/src/main/scala/ca/ferlab/ferload/client/clients/inf/IReportApi.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/clients/inf/IReportApi.scala
@@ -1,6 +1,8 @@
 package ca.ferlab.ferload.client.clients.inf
 
+import ca.ferlab.ferload.client.clients.Error
+
 trait IReportApi {
-  def getManifestContentById(manifestId: String, token: String): List[String]
-  def downloadManifestById(manifestId: String, token: String, path: String): Unit
+  def getManifestContentById(manifestId: String, token: String): Either[Error, List[String]]
+  def downloadManifestById(manifestId: String, token: String, path: String): Either[Error, Unit]
 }

--- a/src/main/scala/ca/ferlab/ferload/client/clients/inf/IReportApi.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/clients/inf/IReportApi.scala
@@ -1,5 +1,6 @@
 package ca.ferlab.ferload.client.clients.inf
 
 trait IReportApi {
-  def getManifestById(manifestId: String, token: String): List[String]
+  def getManifestContentById(manifestId: String, token: String): List[String]
+  def downloadManifestById(manifestId: String, token: String, path: String): Unit
 }

--- a/src/main/scala/ca/ferlab/ferload/client/clients/inf/IReportApi.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/clients/inf/IReportApi.scala
@@ -1,0 +1,5 @@
+package ca.ferlab.ferload.client.clients.inf
+
+trait IReportApi {
+  def getManifestById(manifestId: String, token: String): List[String]
+}

--- a/src/main/scala/ca/ferlab/ferload/client/commands/Configure.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/commands/Configure.scala
@@ -81,9 +81,11 @@ class Configure(userConfig: UserConfig, appConfig: Config, commandLine: ICommand
       } else {
         None
       }
-      val manifestUrl =  if (config.has("reportApiManifestUrl") && !config.isNull("reportApiManifestUrl")) {
-        Some(config.getString("reportApiManifestUrl"))
-      } else None
+
+      config.optString("reportApiManifestUrl") match {
+        case s if s.nonEmpty => userConfig.set(ReportApiManifestUrl, s)
+        case _ =>
+      }
 
       userConfig.set(KeycloakUrl, ferloadConfig.getString("url"))
       userConfig.set(KeycloakRealm, ferloadConfig.getString("realm"))
@@ -94,8 +96,6 @@ class Configure(userConfig: UserConfig, appConfig: Config, commandLine: ICommand
         userConfig.set(ClientManifestFileName, config.getString("manifest-filename"))
         userConfig.set(ClientManifestFileSize, config.getString("manifest-size"))
       })
-
-      manifestUrl.foreach(c => userConfig.set(ReportApiManifestUrl, c))
 
     } else {
       throw new IllegalStateException("Unknown authentication method: " + method)

--- a/src/main/scala/ca/ferlab/ferload/client/commands/Configure.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/commands/Configure.scala
@@ -81,6 +81,10 @@ class Configure(userConfig: UserConfig, appConfig: Config, commandLine: ICommand
       } else {
         None
       }
+      val manifestUrl =  if (config.has("reportApiManifestUrl") && !config.isNull("reportApiManifestUrl")) {
+        Some(config.getString("reportApiManifestUrl"))
+      } else None
+
       userConfig.set(KeycloakUrl, ferloadConfig.getString("url"))
       userConfig.set(KeycloakRealm, ferloadConfig.getString("realm"))
       userConfig.set(KeycloakAudience, ferloadConfig.getString("audience"))
@@ -90,6 +94,8 @@ class Configure(userConfig: UserConfig, appConfig: Config, commandLine: ICommand
         userConfig.set(ClientManifestFileName, config.getString("manifest-filename"))
         userConfig.set(ClientManifestFileSize, config.getString("manifest-size"))
       })
+
+      manifestUrl.foreach(c => userConfig.set(ReportApiManifestUrl, c))
 
     } else {
       throw new IllegalStateException("Unknown authentication method: " + method)

--- a/src/main/scala/ca/ferlab/ferload/client/commands/Download.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/commands/Download.scala
@@ -111,6 +111,7 @@ class Download(userConfig: UserConfig,
 
       }
 
+      //<manifestOnly> option only allowed in case of manifest_id command (-i).
       if (filesDownloadStyle.byManifestId.manifestOnly) {
         downloadManifest(token, padding)
       } else {
@@ -374,16 +375,16 @@ class Download(userConfig: UserConfig,
 object Download {
   //Must supply manifest path OR manifestId
   class FilesDownloadStyle {
-    @Option(names = Array("-m", "--manifest"), description = Array("manifest file location (default: ${DEFAULT-VALUE})"))
+    @Option(names = Array("-m", "--manifest"), required = true, description = Array("manifest file location"))
     var byManifest: Optional[File] = Optional.empty[File]
     @ArgGroup(exclusive = false, multiplicity = "1")
     val byManifestId: ManifestId = new ManifestId()
   }
 
   class ManifestId {
-    @Option(names = Array("-i", "--manifest-id"), description = Array("manifest ID"))
+    @Option(names = Array("-i", "--manifest-id"), required = true, description = Array("manifest ID"))
     var id: Optional[String] = Optional.empty[String]
-    @Option(names = Array("--manifest-only"), description = Array("Download the manifest only from the manifest id"))
+    @Option(names = Array("--manifest-only"), required = false, description = Array("Download the manifest only from the manifest id"))
     var manifestOnly: Boolean = false
   }
 }

--- a/src/main/scala/ca/ferlab/ferload/client/commands/Download.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/commands/Download.scala
@@ -109,9 +109,14 @@ class Download(userConfig: UserConfig,
 
       }
 
-      //<manifestOnly> option only allowed in case of manifest_id command (-i).
-      (if (filesDownloadStyle.byManifestId.manifestOnly) {
-        downloadManifest(token, padding)
+      (if(filesDownloadStyle.byManifestId.id.isPresent){
+        if(filesDownloadStyle.byManifestId.manifestOnly){
+          downloadManifest(token, padding)
+        } else {
+          downloadManifest(token, padding)
+          downloadFiles(token, padding)
+        }
+
       } else {
         downloadFiles(token, padding)
       }) match {
@@ -318,7 +323,7 @@ class Download(userConfig: UserConfig,
 
   private def extractManifest(token: String, padding: Int): Either[Error, ManifestContent] = {
     if (filesDownloadStyle.byManifestId.id.isPresent) {
-      CommandBlock("Extracting Manifest from ID", successEmoji, padding) {
+      CommandBlock("Checking manifest file", successEmoji, padding) {
         fetchAndExtractManifestContentFromId(manifestId = filesDownloadStyle.byManifestId.id.get(), token)
       }
     } else {

--- a/src/main/scala/ca/ferlab/ferload/client/configurations/UserConfigName.scala
+++ b/src/main/scala/ca/ferlab/ferload/client/configurations/UserConfigName.scala
@@ -33,3 +33,5 @@ case object ClientManifestFilePointer extends UserConfigName("client-config-mani
 case object ClientManifestFileName extends UserConfigName("client-config-manifest-filename")
 
 case object ClientManifestFileSize extends UserConfigName("client-config-manifest-size")
+
+case object ReportApiManifestUrl extends UserConfigName("client-config-manifest-url")

--- a/src/test/scala/ca/ferlab/ferload/client/commands/ConfigureTest.scala
+++ b/src/test/scala/ca/ferlab/ferload/client/commands/ConfigureTest.scala
@@ -1,5 +1,6 @@
 package ca.ferlab.ferload.client.commands
 
+import ca.ferlab.ferload.client.clients.Error
 import ca.ferlab.ferload.client.{LineContent, ManifestContent}
 import ca.ferlab.ferload.client.clients.inf.{ICommandLine, IFerload}
 import ca.ferlab.ferload.client.configurations._
@@ -59,25 +60,25 @@ class ConfigureTest extends AnyFunSuite with BeforeAndAfter {
   val mockFerloadInf: IFerload = new IFerload {
     override def getConfig: JSONObject = mockFerloadConfigPassword
 
-    override def getDownloadLinks(token: String, manifestContent: ManifestContent): Map[LineContent, String] = ???
+    override def getDownloadLinks(token: String, manifestContent: ManifestContent): Either[Error, Map[LineContent, String]] = ???
   }
 
   val mockFerloadTokenInf: IFerload = new IFerload {
     override def getConfig: JSONObject = mockFerloadConfigToken
 
-    override def getDownloadLinks(token: String, manifestContent: ManifestContent): Map[LineContent, String] = ???
+    override def getDownloadLinks(token: String, manifestContent: ManifestContent): Either[Error, Map[LineContent, String]] = ???
   }
 
   val mockFerloadDeviceInf: IFerload = new IFerload {
     override def getConfig: JSONObject = mockFerloadConfigDevice
 
-    override def getDownloadLinks(token: String, manifestContent: ManifestContent): Map[LineContent, String] = ???
+    override def getDownloadLinks(token: String, manifestContent: ManifestContent): Either[Error, Map[LineContent, String]] = ???
   }
 
   val mockFerloadUnkownMethodInf: IFerload = new IFerload {
     override def getConfig: JSONObject = new JSONObject().put("method", "foo")
 
-    override def getDownloadLinks(token: String, manifestContent: ManifestContent): Map[LineContent, String] = ???
+    override def getDownloadLinks(token: String, manifestContent: ManifestContent): Either[Error, Map[LineContent, String]] = ???
   }
 
   before {

--- a/src/test/scala/ca/ferlab/ferload/client/commands/DownloadTest.scala
+++ b/src/test/scala/ca/ferlab/ferload/client/commands/DownloadTest.scala
@@ -1,5 +1,6 @@
 package ca.ferlab.ferload.client.commands
 
+import ca.ferlab.ferload.client.clients.Error
 import ca.ferlab.ferload.client.{LineContent, ManifestContent}
 import ca.ferlab.ferload.client.clients.inf.{ICommandLine, IFerload, IKeycloak, IS3}
 import ca.ferlab.ferload.client.configurations._
@@ -85,9 +86,9 @@ class DownloadTest extends AnyFunSuite with BeforeAndAfter {
   }
 
   val mockFerload: IFerload = new IFerload {
-    override def getDownloadLinks(token: String, manifestContent: ManifestContent): Map[LineContent, String] = {
+    override def getDownloadLinks(token: String, manifestContent: ManifestContent): Either[Error, Map[LineContent, String]] = {
       assert(token.equals("token"))
-      Map(LineContent(filePointer = "f1") -> "link1", LineContent(filePointer = "f2") -> "link2", LineContent(filePointer = "f3") -> "link3")
+      Right(Map(LineContent(filePointer = "f1") -> "link1", LineContent(filePointer = "f2") -> "link2", LineContent(filePointer = "f3") -> "link3"))
     }
 
     override def getConfig: JSONObject = mockFerloadConfigPassword


### PR DESCRIPTION
Using the Ferload cli, it is required the functionality to download files using a saved manifest ID. An additional functionality is to fetch the manifest by the ID and save it to the user's machine (without saving the files). 

The manifest is pre-saved and is fetched by its ID using an external service (for CQDG this service is report api). 

See notion page: https://www.notion.so/ferlab/Manifest-ID-d6c5e6c8d03b4b75aa493be98f12381b#9746ee693172425283ee755414310af0


The `download` command of the Ferload cli has an additional `<-i | --manifest-id>` parameter to indicate the user wants to download the files using the manifest id. The `<-m | --manifest>` parameter is still functional as before. However, both -i and -m parameters are optional and mutually exclusive (but one of the 2 is required with the download command).

The sequence was changed slightly for the download command: the authorization is the first action performed, before reading the manifest. 
